### PR TITLE
Added upub user

### DIFF
--- a/src/events/root/van/any/linux/centos7/data/su
+++ b/src/events/root/van/any/linux/centos7/data/su
@@ -2,7 +2,10 @@
 auth		sufficient	pam_rootok.so
 # UMEDIA - START
 # ATTENTION: This file is created automatically by uevents. Don't edit this!
-auth       sufficient   pam_succeed_if.so use_uid user = renders
+auth    sufficient      pam_succeed_if.so use_uid user = renders
+auth    [success=ok default=2]  pam_succeed_if.so user = upub
+auth    [success=ok default=1]  pam_succeed_if.so use_uid user ingroup artists
+auth    [success=done default=ignore]  pam_permit.so
 # UMEDIA - END
 # Uncomment the following line to implicitly trust users in the "wheel" group.
 #auth		sufficient	pam_wheel.so trust use_uid


### PR DESCRIPTION
This pull request adds an exception for the user upub to be able to 'su' without asking for a password. This behavior only happens if the current user is under the "artists" group, otherwise the password for upub is going to be asked as usual.

- Added upub user in van root configuration (#19)