### PR TITLE
shotgun desktop symlink

### DIFF
--- a/src/events/root/van/any/linux/centos7/symlinkShotgunDesktop
+++ b/src/events/root/van/any/linux/centos7/symlinkShotgunDesktop
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+shotgunDesktopLocal="/opt/Shotgun"
+shotgunDesktopRemote="$UPIPE_ROOT/apps/shotgunDesktop/$UVER_SHOTGUNDESKTOP_VERSION/bin/$UCORE_OS/$UCORE_OS_VERSION"
+
+# if we have shotgundesktop installed locally, we need to purge that local installation
+# which is going to be replaced for a symlink. Also, in case we have a symlink
+# we need to remove that as well.
+if [[ -d "$shotgunDesktopLocal" ]]; then
+  rm -rf "$shotgunDesktopLocal"
+elif [[ -L "$shotgunDesktopLocal" ]]; then
+  rm -f "$shotgunDesktopLocal"
+fi
+
+# creating a new fresh symlink pointing to the shotgun desktop version managed
+# by upipe
+ln -s "$shotgunDesktopRemote" "$shotgunDesktopLocal"


### PR DESCRIPTION
Shotgun toolkit looks for shotgundesktop in a hard-coded place under opt. This pull request makes sure the shotgun desktop is going to be the one managed by upipe.

- Making sure shotgun desktop is being managed by upipe.